### PR TITLE
Add an exception for a 401 Unauthorized HTTP Error.

### DIFF
--- a/lib/harvest/api/base.rb
+++ b/lib/harvest/api/base.rb
@@ -43,6 +43,8 @@ module Harvest
             response
           when 400
             raise Harvest::BadRequest.new(response, params)
+          when 401
+            raise Harvest::AuthenticationFailed.new(response, params)
           when 404
             raise Harvest::NotFound.new(response, params)
           when 500

--- a/lib/harvest/errors.rb
+++ b/lib/harvest/errors.rb
@@ -22,4 +22,5 @@ module Harvest
   class InformHarvest < HTTPError; end
   class BadRequest < HTTPError; end
   class ServerError < HTTPError; end
+  class AuthenticationFailed < HTTPError ; end
 end


### PR DESCRIPTION
Harvest returns a 401 when you give them bad credentials. Thought it would be good to make this explicit, and a nice side-effect is that hardy_client won't retry bad credentials, which were being raised before as "InformHarvest" exceptions.
