### PR TITLE
Property hours_without_timer is missing for TimeEntry

### DIFF
--- a/lib/harvest/time_entry.rb
+++ b/lib/harvest/time_entry.rb
@@ -20,6 +20,7 @@ module Harvest
     property :is_billed
     property :timer_started_at
     property :adjustment_record
+    property :hours_without_timer
     
     skip_json_root true
     


### PR DESCRIPTION
The API was updated and this property is missing when trying to add a new timeentry.
