### PR TITLE
Updated User class with weekly_digest_sent_on and wants_weekly_digest and properties

### DIFF
--- a/lib/harvest/user.rb
+++ b/lib/harvest/user.rb
@@ -51,6 +51,8 @@ module Harvest
     property :default_expense_project_id
     property :identity_url
     property :timestamp_timers
+    property :weekly_digest_sent_on
+    property :wants_weekly_digest
     
     alias_method :active?, :is_active
     alias_method :admin?, :is_admin


### PR DESCRIPTION
Hi, Harvest API has probably changed recently and there are new properties in [People API](http://www.getharvest.com/api/people). Although they are not in the documentation you can see them when you dump the retrieved data.
User class tries to set these properties in inherited Dash class and therefore throws these errors:

```
/_path_/hashie/dash.rb:128:in `assert_property_exists!': The property 'wants_weekly_digest' is not defined for this Dash. (NoMethodError)
```

and

```
/_path_/hashie/dash.rb:128:in `assert_property_exists!': The property 'weekly_digest_sent_on' is not defined for this Dash. (NoMethodError)
```
