### PR TITLE
Fix #34 - add missing properties for 2012 beta timesheet

### DIFF
--- a/lib/harvest/user.rb
+++ b/lib/harvest/user.rb
@@ -55,6 +55,7 @@ module Harvest
     property :wants_weekly_digest
     property :password_change_required
     property :has_timesheet_2012_beta
+    property :timesheet_2012_beta_control_group
 
     alias_method :active?, :is_active
     alias_method :admin?, :is_admin


### PR DESCRIPTION
Harvest did it again! Here are the two new properties that we need.
