### PR TITLE
Proxy support via options hash

### DIFF
--- a/lib/harvest/base.rb
+++ b/lib/harvest/base.rb
@@ -6,7 +6,7 @@ module Harvest
     # @see Harvest.hardy_client
     def initialize(subdomain, username, password, options = {})
       options[:ssl] = true if options[:ssl].nil?
-      @credentials = Credentials.new(subdomain, username, password, options[:ssl])
+      @credentials = Credentials.new(subdomain, username, password, options[:ssl], options[:proxy])
       raise InvalidCredentials unless credentials.valid?
     end
 

--- a/lib/harvest/credentials.rb
+++ b/lib/harvest/credentials.rb
@@ -1,9 +1,9 @@
 module Harvest
   class Credentials
-    attr_accessor :subdomain, :username, :password, :ssl
+    attr_accessor :subdomain, :username, :password, :ssl, :proxy
     
-    def initialize(subdomain, username, password, ssl = true)
-      @subdomain, @username, @password, @ssl = subdomain, username, password, ssl
+    def initialize(subdomain, username, password, ssl = true, proxy = nil)
+      @subdomain, @username, @password, @ssl, @proxy = subdomain, username, password, ssl, proxy
     end
     
     def valid?

--- a/spec/support/harvest_credentials.example.yml
+++ b/spec/support/harvest_credentials.example.yml
@@ -4,3 +4,6 @@
 username: "my@email.com"
 password: "secure"
 subdomain: "my-domain"
+# Add a proxy to run the client tests through a proxy.
+# proxyhost: "some.proxy.org"
+# proxyport: 8080

--- a/spec/support/harvested_helpers.rb
+++ b/spec/support/harvested_helpers.rb
@@ -9,12 +9,24 @@ module HarvestedHelpers
     Harvest.client(credentials["subdomain"], credentials["username"], credentials["password"], :ssl => true)
   end
 
+  def self.proxied_harvest
+    if !credentials.has_key?('proxyhost')
+      return HarvestedHelpers.simple_harvest
+    else
+      return Harvest.client(credentials["subdomain"], credentials["username"], credentials["password"], {
+        :ssl => true,
+        :proxy => {:host => credentials['proxyhost'], :port => credentials['proxyport']}
+      })
+    end
+  end
+
   # def connect_to_harvest
   #   @harvest = Harvest.hardy_client(credentials["subdomain"], credentials["username"], credentials["password"], :ssl => true)
   # end
 
   # def harvest; @harvest; end
-  def harvest; @harvest ||= HarvestedHelpers.simple_harvest; end
+
+  def harvest; @harvest ||= HarvestedHelpers.proxied_harvest; end
 
   def hardy_harvest
     Harvest.hardy_client(credentials["subdomain"], credentials["username"], credentials["password"], :ssl => true)


### PR DESCRIPTION
Hi! I needed Harvested to work from behind a proxy, so I added proxy support (as noninvasively as possible), specified in the options hash passed to `Harvest.client` and `Harvest.hardy_client`. For example:

``` ruby
Harvest.client('yoursubdomain', 'yourusername', 'yourpassword', {
  :proxy => {
    :host => 'proxyhost',
    :port => 1234
  }
})
```

Also modified the tests to run through the proxy if `proxyhost` and `proxyport` are specified in `harvest_credentials.yml`.
