### PR TITLE
Trackable projects

### DIFF
--- a/lib/harvest/api/time.rb
+++ b/lib/harvest/api/time.rb
@@ -8,9 +8,11 @@ module Harvest
       end
       
       def all(date = ::Time.now, user = nil)
-        date = ::Time.parse(date) if String === date
-        response = request(:get, credentials, "/daily/#{date.yday}/#{date.year}", :query => of_user_query(user))
-        Harvest::TimeEntry.parse(JSON.parse(response.body)["day_entries"])
+        Harvest::TimeEntry.parse(daily(date, user)["day_entries"])
+      end
+
+      def trackable_projects(date = ::Time.now, user = nil)
+        Harvest::TrackableProject.parse(daily(date, user)["projects"])
       end
       
       def create(entry)
@@ -26,6 +28,15 @@ module Harvest
       def delete(entry, user = nil)
         request(:delete, credentials, "/daily/delete/#{entry.to_i}", :query => of_user_query(user))
         entry.id
+      end
+
+
+      private
+
+      def daily(date, user)
+        date = ::Time.parse(date) if String === date
+        response = request(:get, credentials, "/daily/#{date.yday}/#{date.year}", :query => of_user_query(user))
+        JSON.parse(response.body)
       end
     end
   end

--- a/lib/harvest/trackable_project.rb
+++ b/lib/harvest/trackable_project.rb
@@ -1,0 +1,38 @@
+module Harvest
+
+  # The model for project-tasks combinations that can be added to the timesheet
+  #
+  # == Fields
+  # [+id+] the id of the project
+  # [+name+] the name of the project
+  # [+client+] the name of the client of the project
+  # [+client_id+] the client id of the project
+  # [+tasks+] trackable tasks for the project
+  class TrackableProject < Hashie::Mash
+    include Harvest::Model
+    
+    skip_json_root true
+
+    def initialize(args = {}, _ = nil)
+      args       = args.to_hash.stringify_keys
+      self.tasks = args.delete("tasks") if args["tasks"]
+      super
+    end
+    
+    def tasks=(tasks)
+      self["tasks"] = Task.parse(tasks)
+    end
+  
+    # The model for trackable tasks
+    #
+    # == Fields
+    # [+id+] the id of the task
+    # [+name+] the name of the task
+    # [+billable+] whether the task is billable by default
+    class Task < Hashie::Mash
+      include Harvest::Model
+      
+      skip_json_root true
+    end
+  end
+end

--- a/lib/harvested.rb
+++ b/lib/harvested.rb
@@ -19,7 +19,7 @@ require 'harvest/timezones'
 require 'harvest/base'
 
 %w(crud activatable).each {|a| require "harvest/behavior/#{a}"}
-%w(model client contact project task user rate_limit_status task_assignment user_assignment expense_category expense time_entry invoice_category line_item invoice invoice_payment).each {|a| require "harvest/#{a}"}
+%w(model client contact project task user rate_limit_status task_assignment user_assignment expense_category expense time_entry invoice_category line_item invoice invoice_payment trackable_project).each {|a| require "harvest/#{a}"}
 %w(base account clients contacts projects tasks users task_assignments user_assignments expense_categories expenses time reports invoice_categories invoices invoice_payments).each {|a| require "harvest/api/#{a}"}
 
 module Harvest

--- a/spec/functional/time_tracking_spec.rb
+++ b/spec/functional/time_tracking_spec.rb
@@ -50,4 +50,31 @@ describe 'harvest time tracking' do
   end
 
   it 'allows toggling of timers'
+
+  it 'allows retrieving trackable projects and tasks' do
+    cassette("time_tracking3") do
+      client = harvest.clients.create("name" => "Bobbys Coffee Shop")
+      project = harvest.projects.create("name" => "Bobby's Trackable Project", "client_id" => client.id)
+      harvest.projects.create_task(project, "A billable task for Bobby")
+
+      trackable_projects = harvest.time.trackable_projects
+      trackable_project = trackable_projects.find {|p| p.name == "Bobby's Trackable Project" }
+      trackable_projects.first.client.should == "Bobbys Coffee Shop"
+      trackable_projects.first.tasks.first.name.should == "A billable task for Bobby"
+    end
+  end
+
+  it 'allows for absence of trackable projects' do
+    cassette("time_tracking4") do
+      user = harvest.users.create(
+        "email"      => "gary@example.com",
+        "first_name" => "Gary",
+        "last_name"  => "Doe",
+        "password"   => "secure"
+      )
+
+      trackable_projects = harvest.time.trackable_projects(Time.now, user)
+      trackable_projects.should == []
+    end
+  end
 end

--- a/spec/harvest/trackable_project_spec.rb
+++ b/spec/harvest/trackable_project_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe Harvest::TrackableProject do
+  it "creates task objects" do
+    projects = Harvest::TrackableProject.parse('[{"tasks":[{"id":123}]}]').first
+    projects.tasks.first.id.should == 123
+  end
+end


### PR DESCRIPTION
For a tool I wrote for tracking my hours I needed a list of all the projects/tasks I can track, and I finally got around to implementing it properly with a few specs. (My old implementation with its own API class and without specs can be seen [here](https://github.com/jvdp/harvested/commit/e2332c58d567d34a7e97013130253ac6b80ad78b).)

As it uses the 'daily' endpoint I put it under api/time.rb (with some refactoring). Please let me know what you think. I would like to use my tool with the mainline gem.
