### PR TITLE
Adds support for OAuth 2.0

### DIFF
--- a/lib/harvest/base.rb
+++ b/lib/harvest/base.rb
@@ -4,9 +4,13 @@ module Harvest
 
     # @see Harvest.client
     # @see Harvest.hardy_client
-    def initialize(subdomain, username, password, options = {})
-      options[:ssl] = true if options[:ssl].nil?
-      @credentials = Credentials.new(subdomain, username, password, options[:ssl])
+    def initialize(*args)
+      @credentials = if args.length == 4
+        Credentials.new(*args[0..2], args[3][:ssl])
+      else
+        Credentials.new(*args)
+      end
+
       raise InvalidCredentials unless credentials.valid?
     end
 

--- a/lib/harvest/credentials.rb
+++ b/lib/harvest/credentials.rb
@@ -1,21 +1,68 @@
 module Harvest
   class Credentials
-    attr_accessor :subdomain, :username, :password, :ssl
-    
-    def initialize(subdomain, username, password, ssl = true)
-      @subdomain, @username, @password, @ssl = subdomain, username, password, ssl
+    LEGACY_ARGUMENTS = [:subdomain, :username, :password, :ssl]
+
+    attr_accessor :adapter, :ssl
+
+    def initialize(*args)
+      options = if args.length.between?(3, 4)
+        Hash[LEGACY_ARGUMENTS.zip(args)]
+      elsif args.length == 1
+        args.first
+      else
+        raise ArgumentError, "Invalid arguments passed"
+      end
+
+      @ssl = options.fetch(:ssl) { true }
+
+      adapter_class = options[:access_token] ? OAuth2 : BasicAuth
+      @adapter = adapter_class.new(options)
     end
-    
-    def valid?
-      !subdomain.nil? && !username.nil? && !password.nil?
-    end
-    
-    def basic_auth
-      Base64.encode64("#{username}:#{password}").delete("\r\n")
-    end
-    
+
     def host
-      "#{ssl ? "https" : "http"}://#{subdomain}.harvestapp.com"
+      "#{ssl ? "https" : "http"}://#{domain}"
+    end
+
+    def method_missing(*args, &block)
+      adapter.send(*args, &block)
+    end
+
+    def respond_to_missing?(*args)
+      adapter.respond_to?(*args)
+    end
+
+    class OAuth2 < OpenStruct
+      DOMAIN = "api.harvestapp.com"
+
+      def valid?
+        !access_token.nil?
+      end
+
+      def authenticate_request!(request)
+        query = request.options[:query] ||= {}
+        query[:access_token] = access_token
+      end
+
+      def domain
+        DOMAIN
+      end
+    end
+
+    class BasicAuth < OpenStruct
+      def valid?
+        !subdomain.nil? && !username.nil? && !password.nil?
+      end
+
+      def authenticate_request!(request)
+        request.options[:basic_auth] = {
+          :username => username,
+          :password => password
+        }
+      end
+
+      def domain
+        "#{subdomain}.harvestapp.com"
+      end
     end
   end
 end

--- a/lib/harvested.rb
+++ b/lib/harvested.rb
@@ -30,23 +30,49 @@ module Harvest
     # Creates a standard client that will raise all errors it encounters
     #
     # == Options
+    # * Basic Authentication
+    #   * +:subdomain+ - Your Harvest subdomain
+    #   * +:username+ - Your Harvest username
+    #   * +:password+ - Your Harvest password
+    # * OAuth
+    #   * +:access_token+ - An OAuth 2.0 access token
     # * +:ssl+ - Whether or not to use SSL when connecting to Harvest. This is dependent on whether your account supports it. Set to +true+ by default
     # == Examples
-    #   Harvest.client('mysubdomain', 'myusername', 'mypassword', :ssl => false)
+    #   Harvest.client(:access_token => "anaccestoken", :ssl => false)
+    #
+    #   Harvest.client(
+    #     :subdomain => 'mysubdomain',
+    #     :username => 'myusername',
+    #     :password => 'mypassword',
+    #   )
     #
     # @return [Harvest::Base]
-    def client(subdomain, username, password, options = {})
-      Harvest::Base.new(subdomain, username, password, options)
+    def client(*args)
+      Harvest::Base.new(*args)
     end
 
     # Creates a hardy client that will retry common HTTP errors it encounters and sleep() if it determines it is over your rate limit
     #
     # == Options
+    # * Basic Authentication
+    #   * +:subdomain+ - Your Harvest subdomain
+    #   * +:username+ - Your Harvest username
+    #   * +:password+ - Your Harvest password
+    # * OAuth
+    #   * +:access_token+ - An OAuth 2.0 access token
     # * +:ssl+ - Whether or not to use SSL when connecting to Harvest. This is dependent on whether your account supports it. Set to +true+ by default
     # * +:retry+ - How many times the hardy client should retry errors. Set to +5+ by default.
     #
     # == Examples
-    #   Harvest.hardy_client('mysubdomain', 'myusername', 'mypassword', :ssl => true, :retry => 3)
+    #   Harvest.hardy_client(:access_token => "anaccesstoken", :retry => 9)
+    #
+    #   Harvest.hardy_client(
+    #     :subdomain => 'mysubdomain',
+    #     :username => 'myusername',
+    #     :password => 'mypassword',
+    #     :ssl => true,
+    #     :retry => 3
+    #   )
     #
     # == Errors
     # The hardy client will retry the following errors
@@ -61,9 +87,9 @@ module Harvest
     #
     # @return [Harvest::HardyClient] a Harvest::Base wrapped in a Harvest::HardyClient
     # @see Harvest::Base
-    def hardy_client(subdomain, username, password, options = {})
-      retries = options.delete(:retry)
-      Harvest::HardyClient.new(client(subdomain, username, password, options), (retries || 5))
+    def hardy_client(*args)
+      retries = args.last.respond_to?(:delete) && args.last.delete(:retry)
+      Harvest::HardyClient.new(client(*args), retries || 5)
     end
   end
 end

--- a/spec/harvest/credentials_spec.rb
+++ b/spec/harvest/credentials_spec.rb
@@ -13,10 +13,4 @@ describe Harvest::Credentials do
       Harvest::Credentials.new(nil, nil, nil).should_not be_valid
     end
   end
-  
-  describe "#basic_auth" do
-    it "should base64 encode the credentials" do
-      Harvest::Credentials.new("some-domain", "username", "password").basic_auth.should == "dXNlcm5hbWU6cGFzc3dvcmQ="
-    end
-  end
 end


### PR DESCRIPTION
@zmoazeni thanks for maintaining such a helpful gem. Like the folks in #42 I need OAuth 2.0 support to use this in production, so I added that. My changes are backwards compatible except for some of the internals of `Credentials`. Notably, I decided to use HTTParty's `:basic_auth` option instead of computing the header ourselves. This can be changed back to the old style if for some reason people are using `Credentials` directly.

I introduced a new API for creating clients and recommend we deprecate the old positional argument style (though it still works).

``` ruby
Harvest.client(username: "a", password: "b", subdomain: "c")

Harvest.client(access_token: "asd")
```

Other than the above, nothing else changes. Looking forward to hearing your feedback. Happy to make any changes to get this to your standards. At the very least, this PR still needs an updated README and tests for OAuth. Will add those if you intend to merge.
