### PR TITLE
Recent time entries

### DIFF
--- a/lib/harvest/api/time.rb
+++ b/lib/harvest/api/time.rb
@@ -15,7 +15,7 @@ module Harvest
       end
 
       def recent(limit = 10, days = 7)
-        all(max_days = days)[0..limit]
+        all(max_days = days)[0...limit]
       end
 
       def by_date(date = ::Time.now, user = nil)


### PR DESCRIPTION
Time.all was only returning time entries for a given day, so I renamed it to Time.by_date.  

Time.all (without arguments) behaves exactly as it used to (I didn't break the API).  But _with_ arguments, it now returns multiple days' time entries.

Also added Time.recent, which returns the most recent _limit_ time entries -- by default, the most recent 10 entries over the past week.
