### PR TITLE
Stop throwing away company info

### DIFF
--- a/lib/harvest/api/account.rb
+++ b/lib/harvest/api/account.rb
@@ -15,7 +15,10 @@ module Harvest
       # @return [Harvest::User]
       def who_am_i
         response = request(:get, credentials, '/account/who_am_i')
-        Harvest::User.parse(response.body).first
+        parsed = JSON.parse(response.body)
+        Harvest::User.parse(parsed).first.tap do |user|
+          user.company = parsed["company"]
+        end
       end
     end
   end


### PR DESCRIPTION
Company information is returned as a top-level key in the response to `/account/who_am_i`. By feeding that response directly into `Harvest::User.parse`, we throw away that data. This change preserves that data and makes it accessible by simply tacking it on to the returned user object as the `company` attribute.
